### PR TITLE
ops: nginx: use real hostname for redirs + bind docker logs volume

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,10 +18,11 @@ http {
         listen                  80;
         root                    /www;
         index                   index.html;
-        server_name             localhost, emjpm.num.social.gouv.fr;
+        server_name             emjpm.num.social.gouv.fr;
+        server_name_in_redirect on;
+
         gzip on;
         gzip_disable "msie6";
-
         gzip_vary on;
         gzip_proxied any;
         gzip_comp_level 6;

--- a/update.sh
+++ b/update.sh
@@ -12,4 +12,4 @@ sudo docker build . -t emjpm-app
 
 sudo docker rm -f emjpm-app
 
-sudo docker run -d --restart always --name emjpm-app -p 80:80 emjpm-app
+sudo docker run -d --restart always --name emjpm-app -p 80:80 v $PWD/nginx-logs:/var/log/nginx emjpm-app


### PR DESCRIPTION
règle le problème de redirection de nginx + trailing slashes en forçant le hostname utilisé lors de la redirection absolue.

ajout d'un bound volume au docker pour pouvoir consulter les logs